### PR TITLE
To bugs til i NLKirchhoffShell

### DIFF
--- a/Shell/NLKirchhoffLoveShell.C
+++ b/Shell/NLKirchhoffLoveShell.C
@@ -135,8 +135,8 @@ bool NLKirchhoffLoveShell::evalKandS (Matrix& EK, Vector& ES,
 }
 
 
-bool NLKirchhoffLoveShell::formBmatrix (Matrix& dE_ca, Matrix& dK_ca, Matrix3D ddE_ca,
-                                        Matrix3D ddK_ca,Vec3& E_ca,const Matrix& G0, const Matrix& Gn,
+bool NLKirchhoffLoveShell::formBmatrix (Matrix& dE_ca, Matrix& dK_ca, Matrix3D& ddE_ca,
+                                        Matrix3D& ddK_ca,Vec3& E_ca,const Matrix& G0, const Matrix& Gn,
                                         const Matrix& H0, const Matrix& Hn, Vec3& K_ca,const FiniteElement& fe) const
 {
   // Declaring all variables
@@ -162,6 +162,8 @@ bool NLKirchhoffLoveShell::formBmatrix (Matrix& dE_ca, Matrix& dK_ca, Matrix3D d
     if (!this->getAllMetrics(Gn,Hn,g3,lg3,n,gab,bv,T,false))
       return false;
   }
+
+  const Matrix& Hc = Hn.empty() ? H0 : Hn;
 
   double lg3_3 = lg3*lg3*lg3;
   double lg3_5 = lg3_3*lg3*lg3;
@@ -211,9 +213,9 @@ bool NLKirchhoffLoveShell::formBmatrix (Matrix& dE_ca, Matrix& dK_ca, Matrix3D d
       g3dg3lg3_3(1,i) = g3dg3(1,i)/(lg3_3);
       Vec3 temp = dg3.getColumn(i)/lg3 - g3*g3dg3lg3_3(1,i);                 //*
       dn(1,i) = temp(1); dn(2,i) = temp(2); dn(3,i) = temp(3);               //*
-      dK_cu(1,i) = -(fe.d2NdX2(k,1,1)*n(dir) + Hn.getColumn(1)*dn.getColumn(i)); // changed fe.H to Hn (actualt config)
-      dK_cu(2,i) = -(fe.d2NdX2(k,2,2)*n(dir) + Hn.getColumn(2)*dn.getColumn(i));
-      dK_cu(3,i) = -(fe.d2NdX2(k,1,2)*n(dir) + Hn.getColumn(3)*dn.getColumn(i));
+      dK_cu(1,i) = -(fe.d2NdX2(k,1,1)*n(dir) + Hc.getColumn(1)*dn.getColumn(i)); // changed fe.H to Hc (actualt config)
+      dK_cu(2,i) = -(fe.d2NdX2(k,2,2)*n(dir) + Hc.getColumn(2)*dn.getColumn(i));
+      dK_cu(3,i) = -(fe.d2NdX2(k,1,2)*n(dir) + Hc.getColumn(3)*dn.getColumn(i));
 
     } // for int i = 0; i <= ndof; i++
 
@@ -259,11 +261,11 @@ bool NLKirchhoffLoveShell::formBmatrix (Matrix& dE_ca, Matrix& dK_ca, Matrix3D d
             ddn = ddg3/lg3 - dg3.getColumn(r)*g3dg3lg3_3(1,s)
                 - g3dg3lg3_3(1,r)*dg3.getColumn(s) + C*g3 + D*g3;
             ddK_cu(1) = -(fe.d2NdX2(kr,1,1)*dn(dirr,s) + fe.d2NdX2(ks,1,1)*
-                dn(dirs,r) + Hn(1,1)*ddn(1) + Hn(2,1)*ddn(2) + Hn(3,1)*ddn(3)); // changed fe.H to Hn
+                dn(dirs,r) + Hc(1,1)*ddn(1) + Hc(2,1)*ddn(2) + Hc(3,1)*ddn(3)); // changed fe.H to Hc
             ddK_cu(2) = -(fe.d2NdX2(kr,2,2)*dn(dirr,s) + fe.d2NdX2(ks,2,2)*
-                dn(dirs,r) + Hn(1,2)*ddn(1) + Hn(2,2)*ddn(2) + Hn(3,2)*ddn(3));
+                dn(dirs,r) + Hc(1,2)*ddn(1) + Hc(2,2)*ddn(2) + Hc(3,2)*ddn(3));
             ddK_cu(3) = -(fe.d2NdX2(kr,1,2)*dn(dirr,s) + fe.d2NdX2(ks,1,2)*
-                dn(dirs,r) + Hn(1,3)*ddn(1) + Hn(2,3)*ddn(2) + Hn(3,3)*ddn(3));
+                dn(dirs,r) + Hc(1,3)*ddn(1) + Hc(2,3)*ddn(2) + Hc(3,3)*ddn(3));
             ddK_ca(1,r,s) = T.getRow(1)*ddK_cu;
             ddK_ca(2,r,s) = T.getRow(2)*ddK_cu;
             ddK_ca(3,r,s) = T.getRow(3)*ddK_cu;

--- a/Shell/NLKirchhoffLoveShell.h
+++ b/Shell/NLKirchhoffLoveShell.h
@@ -61,8 +61,8 @@ private:
                  const Matrix& H0, const Matrix& Hn, const Vec3& X) const;
 
   //! \brief Calculates the strain-displacement matrices at current point.
-  bool formBmatrix (Matrix& dE_ca, Matrix& dK_ca, Matrix3D ddE_ca,
-                    Matrix3D ddK_ca,Vec3& E_ca,const Matrix& G0, const Matrix& Gn,
+  bool formBmatrix (Matrix& dE_ca, Matrix& dK_ca, Matrix3D& ddE_ca,
+                    Matrix3D& ddK_ca,Vec3& E_ca,const Matrix& G0, const Matrix& Gn,
                     const Matrix& H0, const Matrix& Hn, Vec3& K_ca,const FiniteElement& fe) const;
 
   //! \brief Calculates all matrics, for both the reference and actual configuration


### PR DESCRIPTION
Etter de siste fiksene dine Torsdag så jeg nå ytterligere to feil:
- Hn er tom i første iterasjon (slik som Gn er) derfor må man bruke H0 når Hn.empty() er true
- Dere har mista noen "&" i signaturen i formBmatrix-metoden.
  Dermed blir de argumentene kopiert i kallet og man får ikke noen verdier ut (de forblir 0).

Men selve med dette konvergerer ikke det lille eksemplet, så det er nok noe mer. Men dette må uansett korrigeres.