### PR TITLE
Added: Framework for calculation of nonlinear stress resultants

### DIFF
--- a/KirchhoffLove.C
+++ b/KirchhoffLove.C
@@ -241,17 +241,18 @@ bool KirchhoffLove::evalSol (Vector& s,
                              const std::vector<int>& MNPC) const
 {
   // Extract element displacements
-  Vector eV;
-  if (!primsol.empty() && !primsol.front().empty())
-  {
-    int ierr = utl::gather(MNPC,npv,primsol.front(),eV);
-    if (ierr > 0)
+  Vectors eV(primsol.size());
+  for (size_t i = 0; i < primsol.size(); i++)
+    if (!primsol[i].empty())
     {
-      std::cerr <<" *** KirchhoffLove::evalSol: Detected "
-                << ierr <<" node numbers out of range."<< std::endl;
-      return false;
+      int ierr = utl::gather(MNPC,npv,primsol[i],eV[i]);
+      if (ierr > 0)
+      {
+        std::cerr <<" *** KirchhoffLove::evalSol: Detected "
+                  << ierr <<" node numbers out of range."<< std::endl;
+        return false;
+      }
     }
-  }
 
   // Evaluate the stress resultants
   return this->evalSol(s,eV,fe,X,true);

--- a/KirchhoffLove.h
+++ b/KirchhoffLove.h
@@ -100,11 +100,11 @@ public:
 
   //! \brief Evaluates the finite element (FE) solution at an integration point.
   //! \param[out] s The FE stress resultant values at current point
-  //! \param[in] eV Element solution vector
+  //! \param[in] eV Element solution vectors
   //! \param[in] fe Finite element data at current point
   //! \param[in] X Cartesian coordinates of current point
   //! \param[in] toLocal If \e true, transform to local coordinates (if defined)
-  virtual bool evalSol(Vector& s, const Vector& eV,
+  virtual bool evalSol(Vector& s, const Vectors& eV,
                        const FiniteElement& fe, const Vec3& X,
                        bool toLocal = false) const = 0;
 

--- a/Linear/KirchhoffLovePlate.h
+++ b/Linear/KirchhoffLovePlate.h
@@ -74,7 +74,7 @@ public:
   //! \param[in] fe Finite element data at current point
   //! \param[in] X Cartesian coordinates of current point
   //! \param[in] toLocal If \e true, transform to local coordinates (if defined)
-  virtual bool evalSol(Vector& s, const Vector& eV,
+  virtual bool evalSol(Vector& s, const Vectors& eV,
                        const FiniteElement& fe, const Vec3& X,
                        bool toLocal = false) const;
 

--- a/Shell/KirchhoffLoveShell.C
+++ b/Shell/KirchhoffLoveShell.C
@@ -234,7 +234,7 @@ bool KirchhoffLoveShell::evalBou (LocalIntegral& elmInt,
 }
 
 
-bool KirchhoffLoveShell::evalSol (Vector& s, const Vector& eV,
+bool KirchhoffLoveShell::evalSol (Vector& s, const Vectors& eV,
                                   const FiniteElement& fe, const Vec3& X,
                                   bool toLocal) const
 {
@@ -265,20 +265,20 @@ bool KirchhoffLoveShell::evalSol (Vector& s, const Vector& eV,
 }
 
 
-bool KirchhoffLoveShell::evalSol (Vector& sm, Vector& sb, const Vector& eV,
+bool KirchhoffLoveShell::evalSol (Vector& sm, Vector& sb, const Vectors& eV,
                                   const FiniteElement& fe, const Vec3& X,
                                   bool toLocal) const
 {
-  if (eV.empty())
+  if (eV.empty() || eV.front().empty())
   {
     std::cerr <<" *** KirchhoffLoveShell::evalSol: No displacement vector."
               << std::endl;
     return false;
   }
-  else if (eV.size() != 3*fe.d2NdX2.dim(1))
+  else if (eV.front().size() != 3*fe.d2NdX2.dim(1))
   {
     std::cerr <<" *** KirchhoffLoveShell::evalSol: Invalid displacement vector."
-              <<"\n     size(eV) = "<< eV.size() <<"   size(d2NdX2) = "
+              <<"\n     size(eV) = "<< eV.front().size() <<"   size(d2NdX2) = "
               << fe.d2NdX2.dim(1) <<","<< fe.d2NdX2.dim(2)*fe.d2NdX2.dim(3)
               << std::endl;
     return false;
@@ -296,9 +296,9 @@ bool KirchhoffLoveShell::evalSol (Vector& sm, Vector& sb, const Vector& eV,
 
   // Evaluate the membran strain and curvature tensors
   SymmTensor epsilon(2), kappa(2);
-  if (!Bm.multiply(eV,epsilon)) // epsilon = B*eV
+  if (!Bm.multiply(eV.front(),epsilon)) // epsilon = B*eV
     return false;
-  if (!Bb.multiply(eV,kappa)) // kappa = B*eV
+  if (!Bb.multiply(eV.front(),kappa)) // kappa = B*eV
     return false;
 
   // Evaluate the stress resultant tensors
@@ -411,7 +411,7 @@ bool KirchhoffLoveShellNorm::evalInt (LocalIntegral& elmInt,
 
   // Evaluate the finite element stress field
   Vector mh, nh, errm, errn;
-  if (!problem.evalSol(nh,mh,pnorm.vec.front(),fe,X))
+  if (!problem.evalSol(nh,mh,pnorm.vec,fe,X))
     return false;
 
   // Evaluate the pressure load and displacement field

--- a/Shell/KirchhoffLoveShell.h
+++ b/Shell/KirchhoffLoveShell.h
@@ -55,24 +55,24 @@ public:
   using KirchhoffLove::evalSol;
   //! \brief Evaluates the finite element (FE) solution at an integration point.
   //! \param[out] s The FE stress resultant values at current point
-  //! \param[in] eV Element solution vector
+  //! \param[in] eV Element solution vectors
   //! \param[in] fe Finite element data at current point
   //! \param[in] X Cartesian coordinates of current point
   //! \param[in] toLocal If \e true, transform to local coordinates (if defined)
-  virtual bool evalSol(Vector& s, const Vector& eV,
+  virtual bool evalSol(Vector& s, const Vectors& eV,
                        const FiniteElement& fe, const Vec3& X,
                        bool toLocal = false) const;
 
   //! \brief Evaluates the finite element (FE) solution at an integration point.
   //! \param[out] sm The FE in-plane stress resultant values at current point
   //! \param[out] sb The FE bending stress resultant values at current point
-  //! \param[in] eV Element solution vector
+  //! \param[in] eV Element solution vectors
   //! \param[in] fe Finite element data at current point
   //! \param[in] X Cartesian coordinates of current point
   //! \param[in] toLocal If \e true, transform to local coordinates (if defined)
-  bool evalSol(Vector& sm, Vector& sb, const Vector& eV,
-               const FiniteElement& fe, const Vec3& X,
-               bool toLocal = false) const;
+  virtual bool evalSol(Vector& sm, Vector& sb, const Vectors& eV,
+                       const FiniteElement& fe, const Vec3& X,
+                       bool toLocal = false) const;
 
   //! \brief Returns max number of 2ndary solution components to print per line.
   virtual size_t getNo2ndSolPerLine() const { return 6; }

--- a/Shell/NLKirchhoffLoveShell.h
+++ b/Shell/NLKirchhoffLoveShell.h
@@ -46,6 +46,16 @@ public:
   virtual bool evalInt(LocalIntegral& elmInt, const FiniteElement& fe,
                        const Vec3& X) const;
 
+  using KirchhoffLoveShell::evalSol;
+  //! \brief Evaluates the finite element (FE) solution at an integration point.
+  //! \param[out] sm The FE in-plane stress resultant values at current point
+  //! \param[out] sb The FE bending stress resultant values at current point
+  //! \param[in] eV Element solution vectors
+  //! \param[in] fe Finite element data at current point
+  //! \param[in] X Cartesian coordinates of current point
+  virtual bool evalSol(Vector& sm, Vector& sb, const Vectors& eV,
+                       const FiniteElement& fe, const Vec3& X, bool) const;
+
 private:
   //! \brief Evaluates the stiffness matrix and internal forces integrand.
   //! \param EK Element matrix to receive the stiffness contributions


### PR DESCRIPTION
Her har dere det som trengs (håper jeg) for at det skal være mulig å beregne konsistente spenningsresultanter for NLKirchhoffShell. Det gjenstår bare å beregne metric'ene Gab, gab, osv, og så tøyningene fra disse, på samme måte som i formBmatrix, og så multiplisere med D-matrisene.
