### PR TITLE
Energy norm calculation for NLKirchhoffLoveShell

### DIFF
--- a/Linear/Test/Results/HemisNL72/Hemisphere72_symm.xinp
+++ b/Linear/Test/Results/HemisNL72/Hemisphere72_symm.xinp
@@ -61,7 +61,6 @@
 	</resultpoints>
 	</postprocessing>
 	<nonlinearsolver>
-<noEnergy/>
         <maxits>30</maxits>
     	<dtol>1.0e8</dtol>
   	</nonlinearsolver>

--- a/Shell/KirchhoffLoveShell.C
+++ b/Shell/KirchhoffLoveShell.C
@@ -498,12 +498,6 @@ bool KirchhoffLoveShellNorm::evalBou (LocalIntegral& elmInt,
 }
 
 
-int KirchhoffLoveShellNorm::getIntegrandType () const
-{
-  return SECOND_DERIVATIVES;
-}
-
-
 size_t KirchhoffLoveShellNorm::getNoFields (int group) const
 {
   if (group == 0)

--- a/Shell/KirchhoffLoveShell.h
+++ b/Shell/KirchhoffLoveShell.h
@@ -147,9 +147,6 @@ public:
   virtual bool evalBou(LocalIntegral& elmInt, const FiniteElement& fe,
                        const Vec3& X, const Vec3& normal) const;
 
-  //! \brief Defines which FE quantities are needed by the integrand.
-  virtual int getIntegrandType() const;
-
   //! \brief Returns whether this norm has explicit boundary contributions.
   virtual bool hasBoundaryTerms() const { return true; }
 


### PR DESCRIPTION
Hvis dere tar inn denne endringen, så kan også energi-norm beregning utføres for den ikke-linære versjonen hvis `<noEnergy/>` fjernes fra input filen,